### PR TITLE
const qualifier added

### DIFF
--- a/src/core/BaseTelemetryContext.cpp
+++ b/src/core/BaseTelemetryContext.cpp
@@ -9,7 +9,7 @@ using namespace ApplicationInsights::core;
 /// Initializes a new instance of the <see cref="BaseTelemetryContext"/> class.
 /// </summary>
 /// <param name="iKey">The i key.</param>
-BaseTelemetryContext::BaseTelemetryContext(std::wstring& iKey)
+BaseTelemetryContext::BaseTelemetryContext(const std::wstring& iKey)
 {
 	m_iKey = iKey;
 }

--- a/src/core/BaseTelemetryContext.h
+++ b/src/core/BaseTelemetryContext.h
@@ -17,7 +17,7 @@ namespace ApplicationInsights
 			/// Initializes a new instance of the <see cref="BaseTelemetryContext"/> class.
 			/// </summary>
 			/// <param name="iKey">The i key.</param>
-			BaseTelemetryContext(std::wstring& iKey);
+			BaseTelemetryContext(const std::wstring& iKey);
 
 			/// <summary>
 			/// Finalizes an instance of the <see cref="BaseTelemetryContext"/> class.

--- a/src/core/TelemetryContext.h
+++ b/src/core/TelemetryContext.h
@@ -19,7 +19,7 @@ namespace ApplicationInsights
 			/// </summary>
 			/// <param name="iKey">The iKey.</param>
 			/// <returns></returns>
-			TelemetryContext(std::wstring& iKey);
+			TelemetryContext(const std::wstring& iKey);
 
 			/// <summary>
 			/// Finalizes an instance of the <see cref=""/> class.

--- a/src/core/TelemetryContextWin32.cpp
+++ b/src/core/TelemetryContextWin32.cpp
@@ -13,7 +13,7 @@ using namespace ApplicationInsights::core;
 /// </summary>
 /// <param name="iKey">The iKey.</param>
 /// <returns></returns>
-TelemetryContext::TelemetryContext(std::wstring& iKey) :
+TelemetryContext::TelemetryContext(const std::wstring& iKey) :
   BaseTelemetryContext(iKey)
 {
 }

--- a/src/core/TelemetryContextWinPhone.cpp
+++ b/src/core/TelemetryContextWinPhone.cpp
@@ -10,7 +10,7 @@ using namespace ApplicationInsights::core;
 /// </summary>
 /// <param name="iKey">The iKey.</param>
 /// <returns></returns>
-TelemetryContext::TelemetryContext(std::wstring& iKey) :
+TelemetryContext::TelemetryContext(const std::wstring& iKey) :
 BaseTelemetryContext(iKey)
 {
 }

--- a/src/core/TelemetryContextWinStore.cpp
+++ b/src/core/TelemetryContextWinStore.cpp
@@ -26,7 +26,7 @@ using namespace Windows::System::Profile;
 /// </summary>
 /// <param name="iKey">The iKey.</param>
 /// <returns></returns>
-TelemetryContext::TelemetryContext(std::wstring& iKey) :
+TelemetryContext::TelemetryContext(const std::wstring& iKey) :
 BaseTelemetryContext(iKey)
 {
 }


### PR DESCRIPTION
The TelemetryContext is never supposed to change the key, so it should be a 'const' parameter to allow clean usage of this class with constant keys.
