### PR TITLE
Fix issue "Remove unnecessary null pointer checks #2". 

### DIFF
--- a/src/core/TelemetryClient.cpp
+++ b/src/core/TelemetryClient.cpp
@@ -22,10 +22,10 @@ using namespace ApplicationInsights::core;
 /// <param name="iKey">The ikey.</param>
 TelemetryClient::TelemetryClient(std::wstring& iKey)
 {
-	m_config = new TelemetryClientConfig(iKey);
-	m_context = new TelemetryContext(iKey);
+	m_config  = std::make_unique<TelemetryClientConfig>(iKey);
+	m_context = std::make_unique<TelemetryContext>(iKey);
 	m_context->InitContext();
-	m_channel = new TelemetryChannel(*m_config);
+	m_channel = std::make_unique<TelemetryChannel>(*m_config);
 }
 
 /// <summary>
@@ -45,11 +45,6 @@ TelemetryClient::~TelemetryClient()
 {
 	// Flush any pending data
 	Flush();
-
-	// Free allocated memory
-	Utils::SafeDelete(m_channel);
-	Utils::SafeDelete(m_context);
-	Utils::SafeDelete(m_config);
 }
 
 /// <summary>

--- a/src/core/TelemetryClient.h
+++ b/src/core/TelemetryClient.h
@@ -32,13 +32,13 @@ namespace ApplicationInsights
 			/// Gets the context.
 			/// </summary>
 			/// <returns>the context</returns>
-			TelemetryContext *GetContext() const { return m_context; }
+			TelemetryContext *GetContext() const { return m_context.get(); }
 
 			/// <summary>
 			/// Gets the configuration.
 			/// </summary>
 			/// <returns>the config</returns>
-			TelemetryClientConfig *GetConfig() const { return m_config; }
+			TelemetryClientConfig *GetConfig() const { return m_config.get(); }
 
 			/// <summary>
 			/// Tracks the event.
@@ -156,14 +156,13 @@ namespace ApplicationInsights
 #endif
 
 			// The config for the instance
-			//std::unique_ptr<TelemetryClientConfig> m_config;
-			TelemetryClientConfig *m_config;
+			std::unique_ptr<TelemetryClientConfig> m_config;
 
 			// The telemetry telemetryContext object.
-			TelemetryContext *m_context;
+			std::unique_ptr<TelemetryContext> m_context;
 
 			// The telemetry channel for this client.
-			TelemetryChannel *m_channel;
+			std::unique_ptr<TelemetryChannel> m_channel;
 		};
 	}
 }

--- a/src/core/common/Utils.h
+++ b/src/core/common/Utils.h
@@ -26,34 +26,6 @@ namespace ApplicationInsights
 			static std::wstring GenerateRandomUUID();
 
 			/// <summary>
-			/// Safely deletes a ptr.
-			/// </summary>
-			/// <param name="ptr">The PTR.</param>
-			template <class T>
-			static void SafeDelete(T& ptr)
-			{
-				if (ptr != nullptr)
-				{
-					delete ptr;
-					ptr = nullptr;
-				}
-			}
-
-			/// <summary>
-			/// Safely deletes an array.
-			/// </summary>
-			/// <param name="ptr">The PTR.</param>
-			template <class T>
-			static void SafeDeleteArray(T& ptr)
-			{
-				if (ptr != nullptr)
-				{
-					delete[] ptr;
-					ptr = nullptr;
-				}
-			}
-
-			/// <summary>
 			/// Writes the debug line.
 			/// </summary>
 			/// <param name="output">The output.</param>

--- a/test/core/TestBasicEndToEnd.cpp
+++ b/test/core/TestBasicEndToEnd.cpp
@@ -94,13 +94,13 @@ namespace core {
 #ifdef WINAPI_FAMILY_PARTITION
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) // phone or store
 				DWORD WaitForResponse() {
-					DWORD ret = ((MockTelemetryChannel *)m_channel)->WaitForResponse();
+					DWORD ret = ((MockTelemetryChannel *)m_channel.get())->WaitForResponse();
 					return ret;
 				}
 #endif 
 #endif
 				HttpResponse GetResponse() {
-					return ((MockTelemetryChannel *)m_channel)->GetResponse();
+					return ((MockTelemetryChannel *)m_channel.get())->GetResponse();
 				}
 
 			};
@@ -137,7 +137,7 @@ namespace core {
 				TEST_METHOD(BasicEndToEnd)
 				{
 					std::wstring iKey = L"ba0f19ca-aa77-4838-ac05-dbba85d6b677";
-					MockTelemetryClient tc = MockTelemetryClient(iKey);
+					MockTelemetryClient tc(iKey);
 
 #ifdef WINAPI_FAMILY_PARTITION
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) // phone or store					

--- a/test/core/TestTelemetryClient.cpp
+++ b/test/core/TestTelemetryClient.cpp
@@ -40,7 +40,7 @@ namespace core {
 				{
 				}
 
-				MockTelemetryChannel *GetChannel() const { return (MockTelemetryChannel*)m_channel; }
+				MockTelemetryChannel *GetChannel() const { return (MockTelemetryChannel*)m_channel.get(); }
 
 			};
 
@@ -61,7 +61,7 @@ namespace core {
 				{
 					std::wstring eventName = L"MY TRACK EVENT";
 					std::wstring iKey = L"MY_IKEY";
-					MockTelemetryClient tc = MockTelemetryClient(iKey);
+					MockTelemetryClient tc(iKey);
 					tc.Flush();
 					tc.TrackEvent(eventName);
 
@@ -74,7 +74,7 @@ namespace core {
 				{
 					std::wstring eventName = L"MY TRACK EVENT";
 					std::wstring iKey = L"MY_IKEY";
-					MockTelemetryClient tc = MockTelemetryClient(iKey);
+					MockTelemetryClient tc(iKey);
 					tc.Flush();
 					tc.DisableTracking();
 
@@ -88,7 +88,7 @@ namespace core {
 				{
 					std::wstring eventName = L"MY TRACK EVENT";
 					std::wstring iKey = L"MY_IKEY";
-					MockTelemetryClient tc = MockTelemetryClient(iKey);
+					MockTelemetryClient tc(iKey);
 					tc.Flush();
 					tc.DisableTracking();
 					tc.TrackEvent(eventName);


### PR DESCRIPTION
Utils::SafeDeleteArray and Utils::SafeDelete were removed completely, because using such functions should be avoided in favour of appropriate manager objects. std::unique_ptr is now used as a replacement in TelemetryClient. Tests were slightly adapted, because the copy-operator can not be used for classes with std::unique_ptr members.
